### PR TITLE
Fixed indexing bug in pq.py

### DIFF
--- a/torch_queue/pq.py
+++ b/torch_queue/pq.py
@@ -31,7 +31,6 @@ def make_path(index):
     """
     order = "{0:b}".format(index + 1)
     order = torch.tensor(list(map(int, order)))
-    print(order)
     out = [1]
     for i in range(1, len(order)):
         out.append(order[i] + 2 * out[-1])
@@ -76,7 +75,7 @@ class Heap:
         items = keys
         if not sorted:
             items, order = torch.sort(items, dim=-1)
-            values = values[:, order]
+            values = values.gather(-1, order)
         self.insert_heapify(items, values, 0, make_path(self.size))
         self.size = self.size + 1
 
@@ -148,15 +147,12 @@ def test_sort(ls):
         x = torch.tensor([l[i * group : (i + 1) * group] for l in ls]).float()
         x, _ = x.sort(dim=-1)
         x = x.view(batch, group)
-        print(x)
         heap.insert(x, x.long())
-        print(heap.storage)
     ks, vs = [], []
     for j in range(size // group):
         k, v = heap.delete_min()
         ks.append(k)
         vs.append(v)
-    print(ks)
     for b in range(batch):
         ls = []
         lsv = []
@@ -206,4 +202,3 @@ def test_path():
     assert make_path(3).tolist() == [0, 1, 3]
     assert make_path(4).tolist() == [0, 1, 4]
     assert make_path(5).tolist() == [0, 2, 5]
-    assert(False)


### PR DESCRIPTION
Currently, the `hypothesis` tests in `pq.py` fail due to a bug in the following function:

https://github.com/srush/torch-queue/blob/e45bc07615a15a5c5c28a270edf52f2a6eaeeb5c/torch_queue/pq.py#L71-L81

Specifically, the `insert` function first sorts `keys` per-batch, then rearranges `values` to match the ordering of this sort -- but if, say

```
values = torch.tensor([[1,2,3],[4,5,6]])
order = torch.tensor([[0,1,2],[2,1,0]])
```

then `values[order]` is
```
tensor([[[1, 2, 3],
         [3, 2, 1]],

        [[4, 5, 6],
         [6, 5, 4]]])
```

rather than `tensor([[1, 2, 3], [6, 5, 4]])` as desired.

This PR changes `values = values[:, order]` to `values = values.gather(-1, order)` in order to fix this bug, and removes some extraneous `print` statements / broken asserts.